### PR TITLE
feat(frontend): add service base urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,10 @@ services:
       dockerfile: Dockerfile
     environment:
       - NODE_ENV=production
+      - NEXT_PUBLIC_API_URL=http://gateway:5000/api/v1
+      - NEXT_PUBLIC_AUTH_URL=http://auth-service:5002/api/v1
+      - NEXT_PUBLIC_PAYMENT_URL=http://payment-service:5100/api/v1
+      - NEXT_PUBLIC_WITHDRAWAL_URL=http://withdrawal-service:5200/api/v1
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_API_URL=http://localhost:5000/api/v1
+NEXT_PUBLIC_AUTH_URL=http://localhost:5002/api/v1
+NEXT_PUBLIC_PAYMENT_URL=http://localhost:5100/api/v1
+NEXT_PUBLIC_WITHDRAWAL_URL=http://localhost:5200/api/v1

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,15 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values for your environment.
+
+- `NEXT_PUBLIC_API_URL` – Base URL for the gateway/back-end API (e.g. http://localhost:5000/api/v1).
+- `NEXT_PUBLIC_AUTH_URL` – Base URL for the auth service.
+- `NEXT_PUBLIC_PAYMENT_URL` – Base URL for the payment service.
+- `NEXT_PUBLIC_WITHDRAWAL_URL` – Base URL for the withdrawal service.
+
 First, run the development server:
 
 ```bash

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,33 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 
-const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+type Service = 'default' | 'auth' | 'payment' | 'withdrawal';
 
-// Attach token secara otomatis
-api.interceptors.request.use(config => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
-    if (token) config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
+const baseURLMap: Record<Service, string | undefined> = {
+  default: process.env.NEXT_PUBLIC_API_URL,
+  auth: process.env.NEXT_PUBLIC_AUTH_URL,
+  payment: process.env.NEXT_PUBLIC_PAYMENT_URL,
+  withdrawal: process.env.NEXT_PUBLIC_WITHDRAWAL_URL,
+};
 
+export const createApi = (service: Service = 'default'): AxiosInstance => {
+  const api = axios.create({
+    baseURL: baseURLMap[service],
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  // Attach token secara otomatis
+  api.interceptors.request.use(config => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('token');
+      if (token) config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  });
+
+  return api;
+};
+
+const api = createApi();
 export default api;


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_* service URLs sample config
- support selecting service base URLs in frontend API utility
- pass service URLs from docker-compose to frontend container

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6f2d327d08328bd70b2a5bbd05d6f