### PR TITLE
feat(frontend): add dedicated API modules

### DIFF
--- a/frontend/src/lib/apiAdmin.ts
+++ b/frontend/src/lib/apiAdmin.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+const adminApi = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_ADMIN_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+adminApi.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export const getAdminUsers = () => adminApi.get('/users');
+export const createAdminUser = (payload: { name: string; email: string; password: string; role: string }) =>
+  adminApi.post('/users', payload);
+
+export default adminApi;

--- a/frontend/src/lib/apiPayment.ts
+++ b/frontend/src/lib/apiPayment.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const paymentApi = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_PAYMENT_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+paymentApi.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export const getPayments = () => paymentApi.get('/payments');
+
+export default paymentApi;

--- a/frontend/src/lib/apiWithdrawal.ts
+++ b/frontend/src/lib/apiWithdrawal.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const withdrawalApi = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_WITHDRAWAL_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+withdrawalApi.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export const getWithdrawals = () => withdrawalApi.get('/withdrawals');
+export const createWithdrawal = (payload: any) => withdrawalApi.post('/withdrawals', payload);
+
+export default withdrawalApi;


### PR DESCRIPTION
## Summary
- add `apiAdmin`, `apiPayment`, and `apiWithdrawal` modules with env-based Axios instances
- include helper methods and token interceptors for consistent API usage

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` *(fails: Could not find '/workspace/launcxupdatebaru/test/**/*.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68a6f78235e88328a45cc49dc65ecae8