### PR TITLE
refactor: use service api modules

### DIFF
--- a/frontend/src/lib/apiAdmin.ts
+++ b/frontend/src/lib/apiAdmin.ts
@@ -21,5 +21,6 @@ adminApi.interceptors.request.use(config => {
 export const getAdminUsers = () => adminApi.get('/users');
 export const createAdminUser = (payload: { name: string; email: string; password: string; role: string }) =>
   adminApi.post('/users', payload);
+export const deleteAdminUser = (id: string) => adminApi.delete(`/users/${id}`);
 
 export default adminApi;

--- a/frontend/src/lib/apiWithdrawal.ts
+++ b/frontend/src/lib/apiWithdrawal.ts
@@ -20,5 +20,9 @@ withdrawalApi.interceptors.request.use(config => {
 
 export const getWithdrawals = () => withdrawalApi.get('/withdrawals');
 export const createWithdrawal = (payload: any) => withdrawalApi.post('/withdrawals', payload);
+export const getClientWithdrawals = (clientId: string, params?: any) =>
+  withdrawalApi.get(`/admin/clients/${clientId}/withdrawals`, { params });
+export const getClientSubwallets = (clientId: string) =>
+  withdrawalApi.get(`/admin/clients/${clientId}/subwallets`);
 
 export default withdrawalApi;


### PR DESCRIPTION
## Summary
- add delete admin user api
- expose client withdrawal helpers
- refactor admin pages to use service modules and show loading/errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next lint interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fa00232c8328b0a22a14f693738c