### PR TITLE
feat: centralize token management and refresh flow

### DIFF
--- a/frontend/src/components/layouts/AdminLayout.tsx
+++ b/frontend/src/components/layouts/AdminLayout.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation'
 import { Menu, Home, Box, LogOut, Settings, BoomBox, ShieldCheck, FileText, User } from 'lucide-react'
 import { motion } from 'framer-motion'
 import styles from './Layout.module.css'
+import { authManager } from '@/lib/authManager'
 
 interface AdminLayoutProps {
   children: ReactNode
@@ -34,7 +35,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
 
   const handleLogout = () => {
     // 1. Hapus token atau session
-    localStorage.removeItem('token')
+    authManager.clearToken('admin')
     // (jika pakai cookie: document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT')
 
     // 2. Redirect ke login

--- a/frontend/src/components/layouts/ClientLayout.tsx
+++ b/frontend/src/components/layouts/ClientLayout.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation'
 import { Menu, Home, CreditCard, Bell, Settings as IconSettings, LogOut } from 'lucide-react'
 import { motion } from 'framer-motion'
 import styles from './ClientLayout.module.css'
+import { authManager } from '@/lib/authManager'
 
 interface ClientLayoutProps {
   children: ReactNode
@@ -29,7 +30,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
 
   const handleLogout = () => {
     // 1) Hapus token
-    localStorage.removeItem('token')
+    authManager.clearToken('client')
     // 2) Redirect ke login
     router.replace('/client/login')
   }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,16 +1,17 @@
 // frontend/src/hooks/useAuth.ts
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { authManager } from '@/lib/authManager'
 
 /**
  * Hook to guard routes that require authentication.
- * Redirects to /login if no token is found in localStorage.
+ * Redirects to /login if no token is found in authManager.
  */
 export function useRequireAuth() {
   const router = useRouter()
 
   useEffect(() => {
-    const token = localStorage.getItem('token')
+    const token = authManager.getToken('admin')
     if (!token) {
       router.replace('/login')
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { attachAuthInterceptor } from './authManager';
 
 type Service = 'default' | 'auth' | 'payment' | 'withdrawal';
 
@@ -17,14 +18,11 @@ export const createApi = (service: Service = 'default'): AxiosInstance => {
     },
   });
 
-  // Attach token secara otomatis
-  api.interceptors.request.use(config => {
-    if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('token');
-      if (token) config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  });
+  attachAuthInterceptor(
+    api,
+    'admin',
+    `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-admin`
+  );
 
   return api;
 };

--- a/frontend/src/lib/apiAdmin.ts
+++ b/frontend/src/lib/apiAdmin.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { attachAuthInterceptor } from './authManager';
 
 const adminApi = axios.create({
   baseURL: process.env.NEXT_PUBLIC_ADMIN_URL,
@@ -7,16 +8,11 @@ const adminApi = axios.create({
   },
 });
 
-adminApi.interceptors.request.use(config => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers = config.headers || {};
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-  }
-  return config;
-});
+attachAuthInterceptor(
+  adminApi,
+  'admin',
+  `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-admin`
+);
 
 export const getAdminUsers = () => adminApi.get('/users');
 export const createAdminUser = (payload: { name: string; email: string; password: string; role: string }) =>

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,143 +1,19 @@
-// File: frontend/src/lib/apiClient.ts
-import axios, { AxiosError, AxiosRequestConfig } from 'axios';
-
-interface ErrorPayload {
-  code?: string;
-  message?: string;
-}
+import axios from 'axios';
+import { attachAuthInterceptor } from './authManager';
 
 const apiClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || '', // contoh: http://localhost:5001/api/v1
-  withCredentials: true, // kalau refresh token di cookie httpOnly
+  baseURL: process.env.NEXT_PUBLIC_API_URL || '',
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
   timeout: 10000,
 });
 
-// state untuk refresh token flow
-let isRefreshing = false;
-let refreshQueue: Array<(token: string | null) => void> = [];
-let hasRedirected = false;
-
-function processQueue(token: string | null) {
-  refreshQueue.forEach(cb => cb(token));
-  refreshQueue = [];
-}
-
-async function attemptTokenRefresh(): Promise<string> {
-  // asumsi endpoint refresh ada dan mengembalikan { accessToken: string }
-  const resp = await axios.post(
-    `${process.env.NEXT_PUBLIC_API_URL || ''}/auth/refresh-client`,
-    {},
-    {
-      withCredentials: true, // jika refresh token di cookie
-      headers: { 'Content-Type': 'application/json' },
-      timeout: 8000,
-    }
-  );
-  const newToken = resp.data?.accessToken;
-  if (!newToken) throw new Error('Refresh gagal: tidak ada token baru');
-  // simpan token baru
-  if (typeof window !== 'undefined') {
-    localStorage.setItem('clientToken', newToken);
-  }
-  return newToken;
-}
-
-// Request interceptor: pasang Authorization jika ada
-apiClient.interceptors.request.use(
-  config => {
-    if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('clientToken');
-      if (token) {
-        config.headers = config.headers || {};
-        config.headers['Authorization'] = `Bearer ${token}`;
-      }
-    }
-    return config;
-  },
-  err => Promise.reject(err)
-);
-
-// Response interceptor: handle expired token / invalid token dengan refresh
-apiClient.interceptors.response.use(
-  response => response,
-  async (error: AxiosError) => {
-    const resp = error.response;
-    const originalConfig = error.config as AxiosRequestConfig & { _retry?: boolean };
-
-    // kalau ga ada response (network error), langsung reject
-    if (!resp) return Promise.reject(error);
-
-    // extract structured error if backend kirim
-    const errData = (resp.data as any)?.error as ErrorPayload | undefined;
-    const errorCode = errData?.code;
-    const errorMessage = errData?.message || (resp.data as any)?.message || '';
-
-    const isAuthError =
-      resp.status === 401 &&
-      (errorCode === 'TOKEN_EXPIRED' ||
-        errorCode === 'INVALID_TOKEN' ||
-        /token/i.test(errorMessage) &&
-          (/expired/i.test(errorMessage) || /invalid/i.test(errorMessage)));
-
-    // handle token expired / invalid dengan refresh sekali
-    if (isAuthError) {
-      if (originalConfig && !originalConfig._retry) {
-        // tunggu refresh jika sudah berjalan
-        if (isRefreshing) {
-          return new Promise((resolve, reject) => {
-            refreshQueue.push(token => {
-              if (token) {
-                if (originalConfig.headers) {
-                  originalConfig.headers['Authorization'] = `Bearer ${token}`;
-                }
-                originalConfig._retry = true;
-                resolve(apiClient.request(originalConfig));
-              } else {
-                reject(error);
-              }
-            });
-          });
-        }
-
-        originalConfig._retry = true;
-        isRefreshing = true;
-
-        try {
-          const newToken = await attemptTokenRefresh();
-          apiClient.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
-          processQueue(newToken);
-          if (originalConfig.headers) {
-            originalConfig.headers['Authorization'] = `Bearer ${newToken}`;
-          }
-          return apiClient.request(originalConfig);
-        } catch (refreshErr) {
-          processQueue(null);
-          // gagal refresh: clear dan redirect sekali
-          if (typeof window !== 'undefined') {
-            localStorage.removeItem('clientToken');
-            if (!hasRedirected) {
-              hasRedirected = true;
-              window.location.href = '/client/login';
-            }
-          }
-          return Promise.reject(refreshErr);
-        } finally {
-          isRefreshing = false;
-        }
-      }
-    }
-
-    // kasus 401 lain yang bukan token-expired/invalid: jangan logout, terus return ke caller
-    if (resp.status === 401 && ['INVALID_TOKEN_SUBJECT', 'CLIENT_USER_NOT_FOUND', 'PARTNER_CLIENT_NOT_FOUND'].includes(errorCode || '')) {
-      return Promise.reject(error);
-    }
-
-    // semua error lain: reject normal
-    return Promise.reject(error);
-  }
+attachAuthInterceptor(
+  apiClient,
+  'client',
+  `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-client`
 );
 
 export default apiClient;

--- a/frontend/src/lib/apiPayment.ts
+++ b/frontend/src/lib/apiPayment.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { attachAuthInterceptor } from './authManager';
 
 const paymentApi = axios.create({
   baseURL: process.env.NEXT_PUBLIC_PAYMENT_URL,
@@ -7,16 +8,11 @@ const paymentApi = axios.create({
   },
 });
 
-paymentApi.interceptors.request.use(config => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers = config.headers || {};
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-  }
-  return config;
-});
+attachAuthInterceptor(
+  paymentApi,
+  'admin',
+  `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-admin`
+);
 
 export const getPayments = () => paymentApi.get('/payments');
 

--- a/frontend/src/lib/apiWithdrawal.ts
+++ b/frontend/src/lib/apiWithdrawal.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { attachAuthInterceptor } from './authManager';
 
 const withdrawalApi = axios.create({
   baseURL: process.env.NEXT_PUBLIC_WITHDRAWAL_URL,
@@ -7,16 +8,11 @@ const withdrawalApi = axios.create({
   },
 });
 
-withdrawalApi.interceptors.request.use(config => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers = config.headers || {};
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-  }
-  return config;
-});
+attachAuthInterceptor(
+  withdrawalApi,
+  'admin',
+  `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-admin`
+);
 
 export const getWithdrawals = () => withdrawalApi.get('/withdrawals');
 export const createWithdrawal = (payload: any) => withdrawalApi.post('/withdrawals', payload);

--- a/frontend/src/lib/authManager.ts
+++ b/frontend/src/lib/authManager.ts
@@ -1,0 +1,96 @@
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
+
+export type UserRole = 'admin' | 'client';
+
+const TOKEN_KEY: Record<UserRole, string> = {
+  admin: 'adminToken',
+  client: 'clientToken',
+};
+
+export const authManager = {
+  getToken(role: UserRole): string | null {
+    if (typeof window === 'undefined') return null;
+    return localStorage.getItem(TOKEN_KEY[role]);
+  },
+  setToken(role: UserRole, token: string) {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(TOKEN_KEY[role], token);
+  },
+  clearToken(role: UserRole) {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(TOKEN_KEY[role]);
+  },
+};
+
+export function attachAuthInterceptor(
+  api: AxiosInstance,
+  role: UserRole,
+  refreshUrl: string
+) {
+  let isRefreshing = false;
+  let queue: Array<(token: string | null) => void> = [];
+
+  const processQueue = (token: string | null) => {
+    queue.forEach(cb => cb(token));
+    queue = [];
+  };
+
+  api.interceptors.request.use(config => {
+    const token = authManager.getToken(role);
+    if (token) {
+      config.headers = config.headers || {};
+      (config.headers as any).Authorization = `Bearer ${token}`;
+    }
+    return config;
+  });
+
+  api.interceptors.response.use(
+    res => res,
+    async (error: AxiosError) => {
+      const status = error.response?.status;
+      const originalConfig = error.config as AxiosRequestConfig & { _retry?: boolean };
+
+      if (status === 401 && originalConfig && !originalConfig._retry) {
+        if (isRefreshing) {
+          return new Promise((resolve, reject) => {
+            queue.push(token => {
+              if (token) {
+                if (originalConfig.headers) {
+                  (originalConfig.headers as any).Authorization = `Bearer ${token}`;
+                }
+                originalConfig._retry = true;
+                resolve(api(originalConfig));
+              } else {
+                reject(error);
+              }
+            });
+          });
+        }
+
+        originalConfig._retry = true;
+        isRefreshing = true;
+
+        try {
+          const resp = await axios.post(refreshUrl, {}, { withCredentials: true });
+          const newToken = (resp.data as any)?.accessToken;
+          if (!newToken) throw new Error('No token returned');
+          authManager.setToken(role, newToken);
+          api.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
+          processQueue(newToken);
+          if (originalConfig.headers) {
+            (originalConfig.headers as any).Authorization = `Bearer ${newToken}`;
+          }
+          return api(originalConfig);
+        } catch (err) {
+          processQueue(null);
+          authManager.clearToken(role);
+          return Promise.reject(err);
+        } finally {
+          isRefreshing = false;
+        }
+      }
+
+      return Promise.reject(error);
+    }
+  );
+}

--- a/frontend/src/pages/client/dashboard.tsx
+++ b/frontend/src/pages/client/dashboard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import api from '@/lib/apiClient'
+import { authManager } from '@/lib/authManager'
 import styles from './ClientDashboard.module.css'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
@@ -172,7 +173,7 @@ export default function ClientDashboardPage() {
 
   // Export Excel
   const handleExport = async () => {
-    const token = localStorage.getItem('clientToken')
+    const token = authManager.getToken('client')
     if (!token) return router.push('/client/login')
 setExporting(true)
     

--- a/frontend/src/pages/client/login/index.tsx
+++ b/frontend/src/pages/client/login/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import apiClient from '@/lib/apiClient'
+import { authManager } from '@/lib/authManager'
 import { X } from 'lucide-react'
 import styles from './ClientAuth.module.css'
 
@@ -58,7 +59,7 @@ export default function LoginForm() {
 
       // on success: clear both state and storage, then redirect
       clearMessage()
-      localStorage.setItem('clientToken', data.token)
+      authManager.setToken('client', data.token)
       router.push('/client/dashboard')
 
     } catch (err: any) {

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import api from '@/lib/api'
+import { authManager } from '@/lib/authManager'
 import { useRequireAuth } from '@/hooks/useAuth'
 import { Wallet, ListChecks, Clock, Layers } from 'lucide-react'
 import styles from './Dashboard.module.css'
@@ -142,7 +143,7 @@ const [withdrawStatusFilter, setWithdrawStatusFilter] = useState('')
   const [perPage, setPerPage] = useState(10)
 
     useEffect(() => {
-    const tok = localStorage.getItem('token')
+    const tok = authManager.getToken('admin')
     if (tok) {
       const payload = parseJwt(tok)
       if (payload?.role === 'SUPER_ADMIN') setIsSuperAdmin(true)

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import api from '@/lib/api'
+import { authManager } from '@/lib/authManager'
 
 import styles from './AdminAuth.module.css'
 
@@ -22,7 +23,7 @@ export default function LoginPage() {
 
       const res = await api.post('/auth/login', payload)
       const token = res.data.result.access_token
-      localStorage.setItem('token', token)
+      authManager.setToken('admin', token)
       window.location.href = '/dashboard'
     } catch (err: any) {
       const msg = err.response?.data?.error


### PR DESCRIPTION
## Summary
- add authManager util for storing tokens per role and refreshing automatically
- update API modules to read and refresh tokens via authManager
- replace direct localStorage usage with authManager for login and logout flows

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt, no linter configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a6fbf339b88328b67cf0fa38c6b22a